### PR TITLE
Fix For Unable To Attach Photo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
+
+## [1.0.2] - in progress
+
+### Fixed
+
+- Addressed issues with attaching files & photos reloading chat
+
+
+## [1.0.1] - 2024-05-06
+
+### Fixed
+
+- Addressed issue handling links
+
+
 ## [1.0.0] - 2024-03-08
 
 ### Added


### PR DESCRIPTION
Added checks to prevent reloading chat view when environment changes.

Then attaching a photo, the chat widget would reload the webview, causing the attach to fail. Now the chat view isn't reloaded for no reason if loading already succeeded.

Combined successful and failed loading of main chat url into an enum to make it easier, rather than different boolean flags.

Known issues: Photo attachment works again now, and links open outside the app, however tapping a link still causes the chat to become blank when returning to the app. This is under investigation, and may be unrelated - it's still an improvement on previous behaviour of link not opening at all but still turning blank.