### PR TITLE
Clear identity cookies from Web view Cookie Store when clearing user data

### DIFF
--- a/Demo/HubspotDemo/ChooseDemoView.swift
+++ b/Demo/HubspotDemo/ChooseDemoView.swift
@@ -68,6 +68,7 @@ struct ChooseDemoView: View {
                     )
                 }
             }
+            .overlayHubspotFloatingActionButton()
             .navigationTitle("Hubspot Demo")
             .toolbar(content: {
                 ToolbarItem(

--- a/Demo/HubspotDemo/Tab And Toolbar Examples/NavToolbarWithChatButtonView.swift
+++ b/Demo/HubspotDemo/Tab And Toolbar Examples/NavToolbarWithChatButtonView.swift
@@ -35,17 +35,14 @@ struct NavToolbarWithChatButtonView: View {
                             Image.hubspotChat
                                 .resizable()
                                 .aspectRatio(contentMode: .fit)
-                                .padding(.vertical, 5)
                             Text("Chat")
                         }
                         .padding(.horizontal)
                         .padding(.vertical, 3)
-                        .background {
-                            Capsule()
-                                .fill(.accent)
-                        }
-                        .foregroundColor(.white)
+                        .foregroundStyle(.white)
                     }
+                    .tint(.accent)
+                    .buttonStyle(.borderedProminent)
                 })
         }
         .sheet(

--- a/Sources/HubspotMobileSDK/Views/ChatView/HubspotChatView.swift
+++ b/Sources/HubspotMobileSDK/Views/ChatView/HubspotChatView.swift
@@ -195,7 +195,7 @@ struct HubspotChatWebView: UIViewRepresentable {
     public typealias UIViewType = WKWebView
 
     /// This is the application name appended to the user agent when embedding chat, including a version, which is manually set for planned release version
-    let applicationNameForUserAgent = "HubspotMobileSDK/1.0.6"
+    let applicationNameForUserAgent = "HubspotMobileSDK/1.0.7"
 
     private let manager: HubspotManager
     private let chatFlow: String?


### PR DESCRIPTION
Based on feedback from issue #13 and discussions in chat with possible fixes, clear the key cookies that hold user identity , even anonymous user identities so that on future access chat doesn't re-open the previous context. Also includes a minor demo cosmetic change to avoid strange toolbar button styling when run on latest ios version