### PR TITLE
feat: Open each chatflow in own WKWebsiteDataStore

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,55 @@
+name: "🤖 Run Tests"
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+    branches:
+      - main
+
+jobs:
+  unit_test:
+    name: "Run unit tests"
+    runs-on: ${{ matrix.runner }}
+
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - destination: "platform=iOS Simulator,name=iPhone 15 Pro,OS=17.5"
+            name: "iPhone 15 Pro (17.5)"
+            runner: macos-15
+            xcode: "16.4"
+          - destination: "platform=iOS Simulator,name=iPhone 16 Pro,OS=18.6"
+            name: "iPhone 16 Pro (18.6)"
+            runner: macos-26
+            xcode: "26.5"
+          - destination: "platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5"
+            name: "iPhone 17 Pro (26.5)"
+            runner: macos-26
+            xcode: "26.5"
+
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
+
+    concurrency:
+      group: unit_tests_${{ matrix.name }}_${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - name: "👀 Check out repository for runner"
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          clean: true
+
+      - name: "🧑‍🔬 ${{ matrix.name }}"
+        run: |
+          xcodebuild test \
+          -scheme HubspotMobileSDK \
+          -destination '${{ matrix.destination }}' \
+          | xcbeautify

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "HubspotMobileSDK",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v15)
+        .iOS(.v17)
     ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.

--- a/Sources/HubspotMobileSDK/ChatThreadInfo.swift
+++ b/Sources/HubspotMobileSDK/ChatThreadInfo.swift
@@ -1,0 +1,17 @@
+// ChatThreadInfo.swift
+// Hubspot Mobile SDK
+//
+// Copyright © 2026 Hubspot, Inc.
+
+import Foundation
+
+/// Describes a chat flow's active conversation thread, reported via ``HubspotManager/threadOpened`` and ``HubspotManager/threadOpenedCallback`` whenever the widget starts a new conversation or the visitor selects an existing one.
+///
+/// This is read-only, informational data - useful for your own persistence or analytics, for example remembering which thread was last active for a given chat flow. It does not control which thread the widget opens.
+public struct ChatThreadInfo: Sendable, Equatable {
+    /// The chat flow this thread belongs to - the same value passed as `chatFlow` when opening ``HubspotChatView``.
+    public let chatFlow: String
+
+    /// The id of the conversation thread.
+    public let threadId: String
+}

--- a/Sources/HubspotMobileSDK/HubspotManager.swift
+++ b/Sources/HubspotMobileSDK/HubspotManager.swift
@@ -4,6 +4,7 @@
 // Copyright © 2024 Hubspot, Inc.
 
 import Combine
+import CryptoKit
 import Foundation
 import OSLog
 import SwiftUI
@@ -74,6 +75,16 @@ public class HubspotManager: NSObject, ObservableObject {
 
     /// Publisher triggered when user opens a hubspot message. Only triggered when manager is acting as the UNNotificationDelegate, or notifications are forwarded to the ``userNotificationCenter(_:didReceive:withCompletionHandler:)`` method on this manager instance.
     public private(set) var newMessage: PassthroughSubject<PushNotificationChatData, Never> = PassthroughSubject()
+
+    /// Callback triggered whenever the chat widget starts a new conversation or the visitor selects
+    /// an existing one.
+    ///
+    /// Read-only - useful for your own persistence or analytics (for example, remembering which thread
+    /// was last active for a given chat flow); it does not control which thread the widget opens.
+    public var threadOpenedCallback: (ChatThreadInfo) -> Void = { _ in }
+
+    /// Publisher triggered whenever the chat widget starts a new conversation or the visitor selects an existing one.
+    public private(set) var threadOpened: PassthroughSubject<ChatThreadInfo, Never> = PassthroughSubject()
 
     /// The logger used by the SDK. to disable logging set to the disabled OSLog with  `Logger(.disabled)`, or set a custom Logger with a preferred subsystem and category
     public var logger = createDefaultHubspotLogger() {
@@ -395,15 +406,101 @@ public class HubspotManager: NSObject, ObservableObject {
         chatProperties = [:]
 
         Task {
-            //The Hubspot chat view currently uses the default web data store
-            let cookieStore = WKWebsiteDataStore.default().httpCookieStore
-            let matchingCookies = await cookieStore.allCookies().filter { cookiesToDeleteWhenClearingData.contains($0.name) }
-            for cookie in matchingCookies {
-                await cookieStore.deleteCookie(cookie)
-            }
+            await clearIdentityCookiesFromAllDataStores()
         }
 
         objectWillChange.send()
+    }
+
+    /// Removes the identity cookies from the default data store, as well as every chat-flow-scoped
+    /// data store the chat view may have created.
+    ///
+    /// Since each chat flow keeps its own isolated data store, clearing user data needs to sweep all
+    /// of them individually to fully reset identity across every chat flow, not just whichever flow
+    /// happens to be open right now.
+    ///
+    /// See ``websiteDataStore(withPushData:forChatFlow:)``.
+    private func clearIdentityCookiesFromAllDataStores() async {
+        await clearIdentityCookies(from: .default())
+
+        guard #available(iOS 17.0, *) else {
+            return
+        }
+
+        let identifiers = await withCheckedContinuation { (continuation: CheckedContinuation<[UUID], Never>) in
+            WKWebsiteDataStore.fetchAllDataStoreIdentifiers { identifiers in
+                continuation.resume(returning: identifiers)
+            }
+        }
+
+        for identifier in identifiers {
+            await clearIdentityCookies(from: WKWebsiteDataStore(forIdentifier: identifier))
+        }
+    }
+
+    private func clearIdentityCookies(from dataStore: WKWebsiteDataStore) async {
+        let cookieStore = dataStore.httpCookieStore
+        let matchingCookies = await cookieStore.allCookies().filter { cookiesToDeleteWhenClearingData.contains($0.name) }
+        for cookie in matchingCookies {
+            await cookieStore.deleteCookie(cookie)
+        }
+    }
+
+    /// Resolves the chat flow to use given push data and an optionally requested chat flow, following the
+    /// same precedence used when building the chat url: push data, then the requested flow, then the
+    /// configured default.
+    func resolveChatFlow(withPushData: PushNotificationChatData?, forChatFlow: String?) -> String? {
+        if let chatFlow = withPushData?.chatflow, !chatFlow.isEmpty {
+            return chatFlow
+        } else if let chatFlow = forChatFlow, !chatFlow.isEmpty {
+            return chatFlow
+        } else if let defaultChatFlow, !defaultChatFlow.isEmpty {
+            return defaultChatFlow
+        }
+        return nil
+    }
+
+    /// Deterministically derives a stable identifier for a chat flow's isolated website data store from
+    /// the portal id and chat flow name.
+    ///
+    /// The same inputs always produce the same identifier, so a given chat flow reuses its own persistent,
+    /// isolated data store across app launches, and different chat flows never collide.
+    private static func dataStoreIdentifier(portalId: String, chatFlow: String) -> UUID {
+        let digest = SHA256.hash(data: Data("\(portalId)|\(chatFlow)".utf8))
+        var bytes = Array(digest.prefix(16))
+        // Force valid UUID version/variant bits - not required functionally, but keeps the identifier looking like a well formed UUID
+        bytes[6] = (bytes[6] & 0x0F) | 0x50
+        bytes[8] = (bytes[8] & 0x3F) | 0x80
+        return bytes.withUnsafeBufferPointer { NSUUID(uuidBytes: $0.baseAddress!) as UUID }
+    }
+
+    /// Returns the website data store to use for a chat session with the given push data / chat flow.
+    ///
+    /// Each chat flow gets its own persistent, isolated data store (see ``dataStoreIdentifier(portalId:chatFlow:)``),
+    /// rather than sharing the default, global data store. HubSpot's chat widget resumes the visitor's
+    /// most recently active conversation thread based on identity cookies - if every chat flow shared one
+    /// data store, opening a different chat flow than the one last used would resume that other flow's
+    /// conversation instead of starting its own. Isolating cookies per chat flow keeps each flow's visitor
+    /// identity, and therefore its active thread, independent of every other flow.
+    ///
+    /// Falls back to the default, shared data store if a chat flow can't be resolved yet (e.g. missing
+    /// configuration) - ``HubspotChatView`` handles that case separately by showing a configuration error
+    /// instead of loading anything.
+    ///
+    /// - Parameters:
+    ///     - withPushData: The struct with data from push notification
+    ///     - forChatFlow: The chat flow to open.
+    ///
+    func websiteDataStore(withPushData: PushNotificationChatData?, forChatFlow: String?) -> WKWebsiteDataStore {
+        guard #available(iOS 17.0, *),
+            let portalId,
+            let resolvedChatFlow = resolveChatFlow(withPushData: withPushData, forChatFlow: forChatFlow)
+        else {
+            return .default()
+        }
+
+        let identifier = Self.dataStoreIdentifier(portalId: portalId, chatFlow: resolvedChatFlow)
+        return WKWebsiteDataStore(forIdentifier: identifier)
     }
 
     /// Computes the url for the current config for embedding chat, based on any known config for portal id, hublet, user id, etc
@@ -424,6 +521,11 @@ public class HubspotManager: NSObject, ObservableObject {
             throw HubspotConfigError.missingConfiguration
         }
 
+        guard let resolvedChatFlow = resolveChatFlow(withPushData: withPushData, forChatFlow: forChatFlow) else {
+            // No chatflow, but we know we need one
+            throw HubspotConfigError.missingChatFlow
+        }
+
         let hubletModel = Hublet(id: hublet, environment: environment)
 
         var components = URLComponents()
@@ -435,6 +537,7 @@ public class HubspotManager: NSObject, ObservableObject {
             "portalId": portalId,
             "hublet": hubletModel.id,
             "env": environment.rawValue,
+            "chatflow": resolvedChatFlow,
         ]
 
         if let idToken = userIdentityToken {
@@ -443,18 +546,6 @@ public class HubspotManager: NSObject, ObservableObject {
 
         if let email = userEmailAddress {
             queryItems["email"] = email
-        }
-
-        // Use chat flow from push data, if exsist, otherwise use chat flow dedicated property
-        if let chatFlow = withPushData?.chatflow, !chatFlow.isEmpty {
-            queryItems["chatflow"] = chatFlow
-        } else if let chatFlow = forChatFlow, !chatFlow.isEmpty {
-            queryItems["chatflow"] = chatFlow
-        } else if let defaultChatFlow, !defaultChatFlow.isEmpty {
-            queryItems["chatflow"] = defaultChatFlow
-        } else {
-            // No chatflow, but we know we need one
-            throw HubspotConfigError.missingChatFlow
         }
 
         var urlNoPlus = CharacterSet.urlQueryAllowed
@@ -481,9 +572,21 @@ public class HubspotManager: NSObject, ObservableObject {
         return url
     }
 
-    /// Handle obtaining a thread id - once the thread id is known , we can post chat properties to the API. This method is used by chat views once they've extracted ID from UI / Javascript Bridge.
-    /// - Parameter threadId: the thread id retrieved from the active chat view
-    func handleThreadOpened(threadId: String) {
+    /// Handle obtaining a thread id - once the thread id is known , we can post chat properties to
+    /// the API, and report it via ``threadOpened``/``threadOpenedCallback``.
+    ///
+    /// This method is used by chat views once they've extracted ID from UI / Javascript Bridge.
+    /// 
+    /// - Parameters:
+    ///   - threadId: the thread id retrieved from the active chat view
+    ///   - chatFlow: the chat flow this thread belongs to, if resolvable
+    func handleThreadOpened(threadId: String, chatFlow: String?) {
+        if let chatFlow {
+            let info = ChatThreadInfo(chatFlow: chatFlow, threadId: threadId)
+            threadOpenedCallback(info)
+            threadOpened.send(info)
+        }
+
         guard let portalId, let hubletModel else {
             return
         }

--- a/Sources/HubspotMobileSDK/Views/Buttons/FloatingActionButton.swift
+++ b/Sources/HubspotMobileSDK/Views/Buttons/FloatingActionButton.swift
@@ -34,6 +34,7 @@ import SwiftUI
 public struct FloatingActionButton: View {
     private let manager: HubspotManager
     private let chatFlow: String?
+    private let openToNewThread: Bool
 
     @State var showingChat: Bool = false
 
@@ -41,12 +42,15 @@ public struct FloatingActionButton: View {
     /// - Parameters:
     ///   - manager: The manager to use for getting a chat session. By defautl the shared manager is used.
     ///   - chatFlow: The specific chat flow to open. Optional.
+    ///   - openToNewThread: Forces the widget to start a new conversation thread instead of resuming the visitor's last active thread - see ``HubspotChatView/init(manager:pushData:chatFlow:openToNewThread:dismissChat:)``. Defaults to `false`.
     public init(
         manager: HubspotManager? = nil,
-        chatFlow: String? = nil
+        chatFlow: String? = nil,
+        openToNewThread: Bool = false
     ) {
         self.manager = manager ?? HubspotManager.shared
         self.chatFlow = chatFlow
+        self.openToNewThread = openToNewThread
     }
 
     public var body: some View {
@@ -65,7 +69,7 @@ public struct FloatingActionButton: View {
         .sheet(
             isPresented: $showingChat,
             content: {
-                HubspotChatView(manager: manager, chatFlow: chatFlow)
+                HubspotChatView(manager: manager, chatFlow: chatFlow, openToNewThread: openToNewThread)
             }
         )
         .onAppear {
@@ -84,17 +88,19 @@ public struct FloatingActionButton: View {
 struct FloatingActionButtonOverlayModifier: ViewModifier {
     let manager: HubspotManager
     let chatFlow: String?
+    let openToNewThread: Bool
 
-    init(manager: HubspotManager? = nil, chatFlow: String? = nil) {
+    init(manager: HubspotManager? = nil, chatFlow: String? = nil, openToNewThread: Bool = false) {
         self.manager = manager ?? HubspotManager.shared
         self.chatFlow = chatFlow
+        self.openToNewThread = openToNewThread
     }
 
     func body(content: Content) -> some View {
         content.overlay(
             alignment: .bottomTrailing,
             content: {
-                FloatingActionButton(manager: manager, chatFlow: chatFlow)
+                FloatingActionButton(manager: manager, chatFlow: chatFlow, openToNewThread: openToNewThread)
                     .padding()
             }
         )
@@ -102,12 +108,19 @@ struct FloatingActionButtonOverlayModifier: ViewModifier {
 }
 
 extension View {
-    /// Convenience to overlay a floating action button - call on your main content view to overlay button at bottom trailing position with default padding. Set the `chatFlow` property to use a specific flow, otherwise the default flow from your configuration file will be used.
+    /// Convenience to overlay a floating action button - call on your main content view to overlay
+    /// button at bottom trailing position with default padding.
+    ///
+    /// Set the `chatFlow` property to use a specific flow, otherwise the default flow from your
+    /// configuration file will be used.
+    ///
     /// - Parameters:
     ///     - manager: The hubspot manager to use
     ///     - chatFlow: the chat flow targeting parameter to use
-    public func overlayHubspotFloatingActionButton(manager: HubspotManager? = nil, chatFlow: String? = nil) -> some View {
-        modifier(FloatingActionButtonOverlayModifier(manager: manager, chatFlow: chatFlow))
+    ///     - openToNewThread: Forces the widget to start a new conversation thread instead of resuming the
+    ///                        visitor's last active thread. Defaults to `false`.
+    public func overlayHubspotFloatingActionButton(manager: HubspotManager? = nil, chatFlow: String? = nil, openToNewThread: Bool = false) -> some View {
+        modifier(FloatingActionButtonOverlayModifier(manager: manager, chatFlow: chatFlow, openToNewThread: openToNewThread))
     }
 }
 

--- a/Sources/HubspotMobileSDK/Views/Buttons/TextChatButtonChatButton.swift
+++ b/Sources/HubspotMobileSDK/Views/Buttons/TextChatButtonChatButton.swift
@@ -15,6 +15,7 @@ public struct TextChatButton: View {
     private let customText: LocalizedStringKey?
     private let manager: HubspotManager
     private let chatFlow: String?
+    private let openToNewThread: Bool
 
     @State var showingChat: Bool = false
 
@@ -24,10 +25,14 @@ public struct TextChatButton: View {
     ///   - text: The text in the button - if nil, default text is used.
     ///   - manager: The manager to use for getting a chat session. By defautl the shared manager is used.
     ///   - chatFlow: The specific chat flow to open. Optional.
-    public init(text: LocalizedStringKey? = nil, manager: HubspotManager? = nil, chatFlow: String? = nil) {
+    ///   - openToNewThread: Forces the widget to start a new conversation thread instead of resuming the
+    ///                      visitor's last active thread - see ``HubspotChatView/init(manager:pushData:chatFlow:openToNewThread:dismissChat:)``.
+    ///                      Defaults to `false`.
+    public init(text: LocalizedStringKey? = nil, manager: HubspotManager? = nil, chatFlow: String? = nil, openToNewThread: Bool = false) {
         customText = text
         self.manager = manager ?? .shared
         self.chatFlow = chatFlow
+        self.openToNewThread = openToNewThread
     }
 
     public var body: some View {
@@ -54,7 +59,7 @@ public struct TextChatButton: View {
         .sheet(
             isPresented: $showingChat,
             content: {
-                HubspotChatView(manager: manager, chatFlow: chatFlow)
+                HubspotChatView(manager: manager, chatFlow: chatFlow, openToNewThread: openToNewThread)
             })
     }
 }

--- a/Sources/HubspotMobileSDK/Views/ChatView/HubspotChatView.swift
+++ b/Sources/HubspotMobileSDK/Views/ChatView/HubspotChatView.swift
@@ -94,6 +94,7 @@ public struct HubspotChatView: View {
     private let manager: HubspotManager
     private let chatFlow: String?
     private let pushData: PushNotificationChatData?
+    private let openToNewThread: Bool
 
     /// If set , use a custom dismiss action, otherwise use environment dismiss
     private let customDismiss: (() -> Void)?
@@ -110,16 +111,27 @@ public struct HubspotChatView: View {
     ///   - manager: manager to use when creating urls for account and getting user properties
     ///   - pushData: Struct containing any of the hubspot values from the push body payload.
     ///   - chatFlow: The specific chat flow to open, if any
-    ///   - dismissChat: If the chat has a close option, you can optionally set this closure to handle closing chat. If you do not set this, then the chat view will use the standard `dismiss` action from the SwiftUI environment - Use this if you show or embed the chat in some custom or non standard presentation.
+    ///   - openToNewThread: HubSpot's web widget resumes the visitor's most recently active conversation
+    ///                      thread when chat is opened, even if that thread belongs to a different chat
+    ///                      flow than the one requested here. Set this to `true` to force the widget to
+    ///                      start a new thread instead - for example, when your app knows it's switching
+    ///                      the user to a different chat flow than the one they last had open.
+    ///                      Defaults to `false`, which preserves the widget's normal resume behaviour.
+    ///   - dismissChat: If the chat has a close option, you can optionally set this closure to handle
+    ///                  closing chat. If you do not set this, then the chat view will use the standard
+    ///                  `dismiss` action from the SwiftUI environment - Use this if you show or embed
+    ///                  the chat in some custom or non standard presentation.
     public init(
         manager: HubspotManager? = nil,
         pushData: PushNotificationChatData? = nil,
         chatFlow: String? = nil,
+        openToNewThread: Bool = false,
         dismissChat: (() -> Void)? = nil
     ) {
         self.manager = manager ?? .shared
         self.chatFlow = chatFlow
         self.pushData = pushData
+        self.openToNewThread = openToNewThread
         customDismiss = dismissChat
     }
 
@@ -131,6 +143,7 @@ public struct HubspotChatView: View {
                 manager: manager,
                 pushData: pushData,
                 chatFlow: chatFlow,
+                openToNewThread: openToNewThread,
                 viewModel: viewModel,
                 dismissAction: {
                     dismissChat()
@@ -200,6 +213,7 @@ struct HubspotChatWebView: UIViewRepresentable {
     private let manager: HubspotManager
     private let chatFlow: String?
     private let pushData: PushNotificationChatData?
+    private let openToNewThread: Bool
 
     @Environment(\.openURL)
     var openURLAction
@@ -218,16 +232,20 @@ struct HubspotChatWebView: UIViewRepresentable {
     ///   - manager: manager to use when creating urls for account and getting user properties
     ///   - pushData: Struct containing any of the hubspot values from the push body payload.
     ///   - chatFlow: The specific chat flow to open, if any
+    ///   - openToNewThread: If true, forces the widget to start a new conversation thread once loaded,
+    ///                      instead of resuming the visitor's last active thread.
     init(
         manager: HubspotManager,
         pushData: PushNotificationChatData?,
         chatFlow: String?,
+        openToNewThread: Bool,
         viewModel: ChatViewModel,
         dismissAction: @escaping () -> Void
     ) {
         self.manager = manager
         self.chatFlow = chatFlow
         self.pushData = pushData
+        self.openToNewThread = openToNewThread
         self.viewModel = viewModel
         self.dismissAction = dismissAction
     }
@@ -243,7 +261,7 @@ struct HubspotChatWebView: UIViewRepresentable {
         coordinator.urlHandler = context.environment.openURL
 
         configuration.applicationNameForUserAgent = applicationNameForUserAgent
-        configuration.websiteDataStore = .default()
+        configuration.websiteDataStore = manager.websiteDataStore(withPushData: pushData, forChatFlow: chatFlow)
 
         configuration.dataDetectorTypes = [.phoneNumber]
 
@@ -299,6 +317,8 @@ struct HubspotChatWebView: UIViewRepresentable {
                 withPushData: pushData,
                 forChatFlow: chatFlow
             )
+            context.coordinator.shouldForceNewThreadOnLoad = openToNewThread
+            context.coordinator.resolvedChatFlow = manager.resolveChatFlow(withPushData: pushData, forChatFlow: chatFlow)
             let request = URLRequest(url: urlToLoad)
 
             Task {
@@ -339,6 +359,25 @@ struct HubspotChatWebView: UIViewRepresentable {
         let contentController = WKUserContentController()
 
         var mainLoadNavReference: WKNavigation?
+
+        /// Mirrors ``HubspotChatWebView/openToNewThread``. When true, once the widget reports it has
+        /// loaded, we force it to start a new conversation thread instead of resuming whatever thread
+        /// the visitor's identity cookies point to.
+        var shouldForceNewThreadOnLoad = false
+
+        /// The chat flow resolved for the current load - reported to the manager alongside any thread
+        /// id extracted from the JS bridge, so ``HubspotManager/threadOpened``/``HubspotManager/threadOpenedCallback``
+        /// observers know which chat flow a thread belongs to.
+        var resolvedChatFlow: String?
+
+        /// Calls the HubSpot Chat Widget SDK's `widget.refresh` with `openToNewThread: true`, if the widget
+        ///  is present. This is the same mechanism HubSpot's web widget uses to avoid resuming a stale
+        ///  thread from a different chat flow.
+        private let forceNewThreadJS = """
+                if (window.HubSpotConversations && window.HubSpotConversations.widget && typeof window.HubSpotConversations.widget.refresh === 'function') {
+                    window.HubSpotConversations.widget.refresh({ openToNewThread: true });
+                }
+            """
 
         func setupScripts() {
             contentController.add(self, name: handlerName)
@@ -454,9 +493,14 @@ struct HubspotChatWebView: UIViewRepresentable {
                 }
 
                 // this message is sent on widget loading
-                if let message = dict["message"] as? String, message == "widget has loaded" {
+                if let messageText = dict["message"] as? String, messageText == "widget has loaded" {
                     Task {
                         await viewModel.didLoadWidget()
+                    }
+
+                    if shouldForceNewThreadOnLoad {
+                        shouldForceNewThreadOnLoad = false
+                        message.webView?.evaluateJavaScript(forceNewThreadJS)
                     }
                 }
 
@@ -467,12 +511,12 @@ struct HubspotChatWebView: UIViewRepresentable {
                     #if compiler(<6)
                         // Adding an assume isolated for Xcode 15 support - this isn't needed in Xcode 16, but the WKScriptMessageHandler doesn't have the main actor isolation
                         MainActor.assumeIsolated {
-                            manager.handleThreadOpened(threadId: String(conversationId))
+                            manager.handleThreadOpened(threadId: String(conversationId), chatFlow: resolvedChatFlow)
                         }
 
                     #else
                         // Now we know the id of newly selected thread, we can inform the manager which will handle next steps for data
-                        manager.handleThreadOpened(threadId: String(conversationId))
+                        manager.handleThreadOpened(threadId: String(conversationId), chatFlow: resolvedChatFlow)
                     #endif
                 }
             default:

--- a/Tests/HubspotMobileSDKTests/ChatFlowRoutingTests.swift
+++ b/Tests/HubspotMobileSDKTests/ChatFlowRoutingTests.swift
@@ -1,0 +1,187 @@
+// ChatFlowRoutingTests.swift
+// Hubspot Mobile SDK
+//
+// Copyright © 2026 Hubspot, Inc.
+
+import Combine
+import Testing
+import WebKit
+
+@testable import HubspotMobileSDK
+
+@MainActor
+struct ResolveChatFlowTests {
+
+    @Test
+    func usesConfiguredDefaultWhenNothingElseProvided() {
+        let manager = HubspotManager()
+        manager.configure(portalId: "123", hublet: "na1", defaultChatFlow: "default-flow")
+
+        #expect(manager.resolveChatFlow(withPushData: nil, forChatFlow: nil) == "default-flow")
+    }
+
+    @Test
+    func explicitChatFlowOverridesConfiguredDefault() {
+        let manager = HubspotManager()
+        manager.configure(portalId: "123", hublet: "na1", defaultChatFlow: "default-flow")
+
+        #expect(manager.resolveChatFlow(withPushData: nil, forChatFlow: "explicit-flow") == "explicit-flow")
+    }
+
+    @Test
+    func pushDataChatFlowTakesPrecedenceOverExplicitAndDefault() {
+        let manager = HubspotManager()
+        manager.configure(portalId: "123", hublet: "na1", defaultChatFlow: "default-flow")
+        let pushData = PushNotificationChatData(notificationData: ["hsChatflowParam": "push-flow"])
+
+        #expect(manager.resolveChatFlow(withPushData: pushData, forChatFlow: "explicit-flow") == "push-flow")
+    }
+
+    @Test
+    func returnsNilWhenNoChatFlowIsResolvable() {
+        let manager = HubspotManager()
+        manager.configure(portalId: "123", hublet: "na1", defaultChatFlow: nil)
+
+        #expect(manager.resolveChatFlow(withPushData: nil, forChatFlow: nil) == nil)
+    }
+}
+
+@MainActor
+struct ChatUrlTests {
+    @Test
+    func includesResolvedChatFlowInQuery() throws {
+        let manager = HubspotManager()
+        manager.configure(portalId: "123", hublet: "na1", defaultChatFlow: nil)
+
+        let url = try manager.chatUrl(withPushData: nil, forChatFlow: "sales")
+
+        let query = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems)
+        #expect(query.contains { $0.name == "chatflow" && $0.value == "sales" })
+        #expect(query.contains { $0.name == "portalId" && $0.value == "123" })
+    }
+
+    @Test
+    func throwsMissingChatFlowWhenNoneResolvable() {
+        let manager = HubspotManager()
+        manager.configure(portalId: "123", hublet: "na1", defaultChatFlow: nil)
+
+        do {
+            _ = try manager.chatUrl(withPushData: nil, forChatFlow: nil)
+            Issue.record("Expected chatUrl to throw missingChatFlow")
+        } catch HubspotConfigError.missingChatFlow {
+            // expected
+        } catch {
+            Issue.record("Expected missingChatFlow, got \(error)")
+        }
+    }
+
+    @Test
+    func throwsMissingConfigurationWhenUnconfigured() {
+        let manager = HubspotManager()
+
+        do {
+            _ = try manager.chatUrl(withPushData: nil, forChatFlow: "sales")
+            Issue.record("Expected chatUrl to throw missingConfiguration")
+        } catch HubspotConfigError.missingConfiguration {
+            // expected
+        } catch {
+            Issue.record("Expected missingConfiguration, got \(error)")
+        }
+    }
+}
+
+@MainActor
+struct WebsiteDataStoreIsolationTests {
+    @Test
+    func sameChatFlowReusesTheSamePersistentStore() async throws {
+        let manager = HubspotManager()
+        manager.configure(portalId: "isolation-test-portal", hublet: "na1", defaultChatFlow: nil)
+
+        let firstLookup = manager.websiteDataStore(withPushData: nil, forChatFlow: "flow-a")
+        let secondLookup = manager.websiteDataStore(withPushData: nil, forChatFlow: "flow-a")
+
+        let cookie = try #require(HTTPCookie(properties: [
+            .name: "hubspotutk",
+            .value: "same-flow-value",
+            .domain: "example.com",
+            .path: "/",
+        ]))
+        await firstLookup.httpCookieStore.setCookie(cookie)
+
+        let cookiesSeenBySecondLookup = await secondLookup.httpCookieStore.allCookies()
+        #expect(cookiesSeenBySecondLookup.contains { $0.name == "hubspotutk" && $0.value == "same-flow-value" })
+
+        // cleanup so repeated test runs on the same simulator don't accumulate cookies
+        await firstLookup.httpCookieStore.deleteCookie(cookie)
+    }
+
+    @Test
+    func differentChatFlowsGetIsolatedStores() async throws {
+        let manager = HubspotManager()
+        manager.configure(portalId: "isolation-test-portal", hublet: "na1", defaultChatFlow: nil)
+
+        let flowAStore = manager.websiteDataStore(withPushData: nil, forChatFlow: "flow-b1")
+        let flowBStore = manager.websiteDataStore(withPushData: nil, forChatFlow: "flow-b2")
+
+        let cookie = try #require(HTTPCookie(properties: [
+            .name: "hubspotutk",
+            .value: "flow-a-value",
+            .domain: "example.com",
+            .path: "/",
+        ]))
+        await flowAStore.httpCookieStore.setCookie(cookie)
+
+        let cookiesSeenByOtherFlow = await flowBStore.httpCookieStore.allCookies()
+        #expect(!cookiesSeenByOtherFlow.contains { $0.name == "hubspotutk" })
+
+        await flowAStore.httpCookieStore.deleteCookie(cookie)
+    }
+
+    @Test
+    func fallsBackToDefaultStoreWhenChatFlowUnresolvable() {
+        let manager = HubspotManager()
+        manager.configure(portalId: "isolation-test-portal", hublet: "na1", defaultChatFlow: nil)
+
+        let store = manager.websiteDataStore(withPushData: nil, forChatFlow: nil)
+
+        #expect(store === WKWebsiteDataStore.default())
+    }
+}
+
+@MainActor
+struct ThreadOpenedReportingTests {
+    @Test
+    func reportsChatThreadInfoViaCallbackAndPublisher() async {
+        let manager = HubspotManager()
+
+        var reportedViaCallback: ChatThreadInfo?
+        manager.threadOpenedCallback = { info in
+            reportedViaCallback = info
+        }
+
+        var reportedViaPublisher: ChatThreadInfo?
+        var cancellables = Set<AnyCancellable>()
+        manager.threadOpened.sink { info in
+            reportedViaPublisher = info
+        }.store(in: &cancellables)
+
+        manager.handleThreadOpened(threadId: "999", chatFlow: "sales")
+
+        #expect(reportedViaCallback == ChatThreadInfo(chatFlow: "sales", threadId: "999"))
+        #expect(reportedViaPublisher == ChatThreadInfo(chatFlow: "sales", threadId: "999"))
+    }
+
+    @Test
+    func doesNotReportWhenChatFlowIsUnknown() {
+        let manager = HubspotManager()
+
+        var reported = false
+        manager.threadOpenedCallback = { _ in
+            reported = true
+        }
+
+        manager.handleThreadOpened(threadId: "999", chatFlow: nil)
+
+        #expect(!reported)
+    }
+}


### PR DESCRIPTION
### 📣 Summary

Fixes reopening a chatflow showing the content of a *different*, still-active chatflow (#19). When a user started a conversation in chatflow A, dismissed it, then opened chatflow B, the SDK would show chatflow A's conversation — because HubSpot's chat widget resumes "the visitor's most recently active thread" based on identity cookies (`hubspotutk`/`messagesUtk`), and every chatflow previously shared the same global `WKWebsiteDataStore.default()`. `clearUserData()` didn't reliably fix this either, since it only cleared the default store.

This PR gives each chatflow its own persistent, isolated `WKWebsiteDataStore`, so chatflows never bleed into each other's conversation state — opening chatflow B always shows B (latest opened thread or a new thread), and returning to chatflow A later still correctly resumes A's own conversation.

Works for anonymous visitors only.

### 📝 Items of Note

- **Bumps minimum deployment target from iOS 15 → iOS 17** (`Package.swift`). Required for `WKWebsiteDataStore(forIdentifier:)` / `WKWebsiteDataStore.fetchAllDataStoreIdentifiers`, which are iOS 17+ only. This is a breaking change for any consumer app still supporting iOS 15/16.
- Confirmed with HubSpot's Chat Widget SDK docs that there's no supported way to resume a *specific* conversation thread by id — `widget.refresh` only supports "resume most recent thread" (default) or "start a brand new thread" (`openToNewThread: true`). Per-chatflow data store isolation sidesteps this entirely by giving each chatflow its own identity, rather than trying to pick a specific thread.
- `HubspotManager.websiteDataStore(withPushData:forChatFlow:)` derives a stable, deterministic `UUID` from `SHA256(portalId + chatflow)`, so the same chatflow always maps to the same isolated store across app launches without needing to persist a lookup table anywhere.
- `clearUserData()` now sweeps identity cookies from **every** known per-chatflow data store (via `WKWebsiteDataStore.fetchAllDataStoreIdentifiers`), not just `.default()`, since visitor identity no longer lives in one shared place.
- Added `openToNewThread: Bool = false` to `HubspotChatView`, `FloatingActionButton`, and `TextChatButton` — lets an app explicitly force a fresh conversation (via `HubSpotConversations.widget.refresh({ openToNewThread: true })`) within the *same* chatflow, e.g. a "start new chat" action. Defaults to `false`, so existing callers are unaffected.
- Added a new `ChatThreadInfo` struct plus `HubspotManager.threadOpened` (Combine publisher) / `threadOpenedCallback`, mirroring the existing `newMessage`/`newMessageCallback` pattern. Reports `(chatFlow, threadId)` whenever the widget starts or selects a conversation — read-only, for the host app's own persistence/analytics; it does not control which thread the widget opens.
- All new `WKWebsiteDataStore(forIdentifier:)` / `fetchAllDataStoreIdentifiers` call sites are guarded with `#available(iOS 17.0, *)`, falling back to `.default()` below that, as defense in depth alongside the raised deployment target.
- Added a GitHub Actions workflow (`.github/workflows/test.yml`) that runs the unit test suite on every PR into `main`, across a simulator matrix (iPhone 15 Pro/17.5, 16 Pro/18.5, 17 Pro/26.5) via `xcodebuild` test. See GitHub Actions workflow results at https://github.com/surpher/mobile-chat-sdk-ios/actions/.
- I did not verify remote notification handling as we are not using SDK's delegate to handle notifications.

### 🚦 Release Plan

Raising the deployment target to iOS 17 is a breaking change, so these changes, if accepted, can be released as a new major version rather than a patch on the current line:

- **`v1.x`** — cut a protected `release/1.x` maintenance branch from the last pre-this-PR commit on `main`. It keeps supporting iOS 15+ and only receives backported critical/minor fixes going forward; no new features land there.
- **`v2.x`** — this PR becomes `v2.0.0`, the new `main` line, requiring iOS 17+. All new feature work (including this chatflow-isolation fix) lands here going forward.

Consumers on iOS 15/16 stay on `1.x` until they can raise their own deployment target; everyone else upgrades to `2.x` to get this fix.

Potentially the changes in this PR can be rewritten with new `#available(iOS 17, *)` interfaces only. Though `SwiftUI` code already forks the View based on iOS version and our own product supports 17+, this approach fits our own needs.

### 🧪 Testing

- Manually reproduced the original bug end-to-end using two chatflows (`default` / `updates`) following the repro steps from the linked issue, on both simulator and device — confirmed chatflow B now always opens as B, and re-opening chatflow A afterwards resumes A's own conversation.
- Added `Tests/HubspotMobileSDKTests/ChatFlowRoutingTests.swift` (Swift Testing), covering:
  - chatflow resolution precedence (push data > explicit `chatFlow` > configured default)
  - `chatUrl` includes the resolved `chatflow` query param and throws the correct `HubspotConfigError` cases
  - `websiteDataStore` isolation: same chatflow reuses the same persistent store, different chatflows are isolated from each other, and an unresolvable chatflow falls back to `.default()`
  - `threadOpened` / `threadOpenedCallback` fire with the right `ChatThreadInfo` when a chatflow is known, and stay silent when it isn't
- Full suite (3 existing + 12 new) passes via `xcodebuild test` against an iOS 17 simulator.
- Not covered by automated tests: `clearUserData()`'s per-chatflow cookie sweep runs in a fire-and-forget `Task`, so it isn't easily awaitable from a test without a refactor — verified manually instead.
